### PR TITLE
Teleposer Blacklist - AM2 Liquid Essence

### DIFF
--- a/config/AWWayofTime.cfg
+++ b/config/AWWayofTime.cfg
@@ -207,6 +207,7 @@ orecrushing {
     # Stops specified blocks from being teleposed. Put entries on new lines. Valid syntax is: 
     # modid:blockname:meta
     S:Blacklist <
+        arsmagica2:liquidEssence
      >
 }
 


### PR DESCRIPTION
Behaves improperly with BM Ritual - Blood of the New Moon which calls the teleposer function to operate.